### PR TITLE
🎨 Create nodejs renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 dist/*
-!dist/README.md

--- a/app/render.js
+++ b/app/render.js
@@ -1,3 +1,7 @@
-module.exports = function render(data) {
-  return '';
+const nunjucks = require('nunjucks');
+
+nunjucks.configure({ autoescape: true, throwOnUndefined: true });
+
+module.exports = function render(template, data) {
+  return nunjucks.render(template, data);
 };

--- a/components/index.njk
+++ b/components/index.njk
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>Together Science Can</title>
+  <link rel="stylesheet" type="text/css" href="styles-{{ hash }}.css">
 </head>
 <body>
 </body>

--- a/components/index.scss
+++ b/components/index.scss
@@ -1,0 +1,3 @@
+body {
+  background: black;
+}

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,1 +1,0 @@
-This is the directory where the static site gets built.

--- a/index.js
+++ b/index.js
@@ -6,13 +6,14 @@ const render = require('./app/render.js');
 
 const OUTPUT_FILE_NAME = 'index.html';
 
-const html = render('./components/index.njk', content);
+const hash = Date.now();
+const html = render('./components/index.njk', Object.assign(content, { hash }));
 
 fs.writeFile(
   path.join(__dirname, 'dist', OUTPUT_FILE_NAME),
   html,
   err => {
     if (err)  throw err;
-    else      console.log(`Generated ${OUTPUT_FILE_NAME}.`);
+    else      process.stdout.write(hash.toString());
   }
 );

--- a/index.js
+++ b/index.js
@@ -6,10 +6,10 @@ const render = require('./app/render.js');
 
 const OUTPUT_FILE_NAME = 'index.html';
 
-const html = render(content);
+const html = render('./components/index.njk', content);
 
 fs.writeFile(
-  path.join(__dirname, 'build', OUTPUT_FILE_NAME),
+  path.join(__dirname, 'dist', OUTPUT_FILE_NAME),
   html,
   err => {
     if (err)  throw err;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "a-sync-waterfall": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.0.tgz",
+      "integrity": "sha1-OOgxnXk3niRiiEW1O5ZyKyng5Hw="
+    },
     "abbrev": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
@@ -166,6 +171,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.3",
@@ -4547,6 +4557,79 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "nunjucks": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.0.1.tgz",
+      "integrity": "sha1-TedKPlULr2+jNwMj89HHwqhr3E0=",
+      "requires": {
+        "a-sync-waterfall": "1.0.0",
+        "asap": "2.0.6",
+        "chokidar": "1.7.0",
+        "yargs": "3.32.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "window-size": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+          "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "requires": {
+            "camelcase": "2.1.1",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "os-locale": "1.4.0",
+            "string-width": "1.0.2",
+            "window-size": "0.1.4",
+            "y18n": "3.2.1"
+          }
+        }
+      }
     },
     "oauth-sign": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Site for the Together Science Can campaign",
   "main": "index.js",
   "scripts": {
-    "build:html": "node index.js",
-    "build:cssjs": "webpack --config webpack.config.prod.js",
-    "build:cssjs:dev": "webpack --config webpack.config.dev.js",
-    "watch": "nodemon --watch components --ext 'njk js scss' --exec 'npm run build:html && npm run build:cssjs:dev'",
+    "build": "npm run clean-dist && webpack --config webpack.config.prod.js --define \"$(node index.js)\"",
+    "build:dev": "npm run clean-dist && webpack --config webpack.config.dev.js --define \"$(node index.js)\"",
+    "watch": "nodemon --watch components --ext 'njk js scss' --exec 'npm run build:dev'",
+    "clean-dist": "rm dist/*.map && rm dist/*.css && rm dist/*.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "npm run clean-dist && webpack --config webpack.config.prod.js --define \"$(node index.js)\"",
     "build:dev": "npm run clean-dist && webpack --config webpack.config.dev.js --define \"$(node index.js)\"",
     "watch": "nodemon --watch components --ext 'njk js scss' --exec 'npm run build:dev'",
-    "clean-dist": "rm dist/*.map && rm dist/*.css && rm dist/*.js",
+    "clean-dist": "mkdir -p dist && rm -rf dist/*",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-loader": "^1.9.0",
     "extract-text-webpack-plugin": "^3.0.0",
     "node-sass": "^4.5.3",
+    "nunjucks": "^3.0.1",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.18.2",
     "webpack": "^3.5.4"

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -5,40 +5,40 @@ const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const scss = new ExtractTextPlugin({ filename: 'styles.css' });
 
 module.exports = {
-    entry: path.join(__dirname, 'components', 'index.js'),
-    output: {
-        path: path.join(__dirname, 'build'),
-        filename: 'main.js'
-    },
-    devtool: 'cheap-module-source-map', // enable source maps
-    module: {
-        loaders: [
-              {
-                    test: /\.js$/,
-                    exclude: /node_modules/,
-                    loaders: ['babel-loader?presets[]=env', 'eslint-loader?fix=true']
-              },
-              {
-                  test: /\.scss$/,
-                  use: scss.extract({
-                      use: [
-                        {
-                            loader: "css-loader",
-                            options: { sourceMap: true }
-                        },
-                        {
-                            loader: "sass-loader",
-                            options: { sourceMap: true }
-                        }
-                      ]
-                  })
-              }
-        ]
-    },
-    plugins: [
-        new webpack.DefinePlugin({
-            ENV: { development: true }
-        }),
-        scss
+  entry: path.join(__dirname, 'components', 'index.js'),
+  output: {
+    path: path.join(__dirname, 'build'),
+    filename: 'main.js'
+  },
+  devtool: 'cheap-module-source-map', // enable source maps
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loaders: ['babel-loader?presets[]=env', 'eslint-loader?fix=true']
+      },
+      {
+        test: /\.scss$/,
+        use: scss.extract({
+          use: [
+            {
+              loader: "css-loader",
+              options: { sourceMap: true }
+            },
+            {
+              loader: "sass-loader",
+              options: { sourceMap: true }
+            }
+          ]
+        })
+      }
     ]
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      ENV: { development: true }
+    }),
+    scss
+  ]
 }

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -2,6 +2,10 @@ const webpack = require('webpack');
 const path = require('path');
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 
+// here we get the hash created by the HTML generator,
+// which is passed to us in the --define CLI arg
+// --define isn't supposed to be used like this, but we're not using it for anything else so why not.
+// Webpack throws on unknown CLI args.
 // we're certain that the --define options is specified, so this is safe
 const hash = process.argv[process.argv.indexOf('--define') + 1];
 

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -2,13 +2,16 @@ const webpack = require('webpack');
 const path = require('path');
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 
-const scss = new ExtractTextPlugin({ filename: 'styles.css' });
+// we're certain that the --define options is specified, so this is safe
+const hash = process.argv[process.argv.indexOf('--define') + 1];
+
+const scss = new ExtractTextPlugin({ filename: `styles-${hash}.css` });
 
 module.exports = {
   entry: path.join(__dirname, 'components', 'index.js'),
   output: {
-    path: path.join(__dirname, 'build'),
-    filename: 'main.js'
+    path: path.join(__dirname, 'dist'),
+    filename: `main-${hash}.js`
   },
   devtool: 'cheap-module-source-map', // enable source maps
   module: {
@@ -24,7 +27,7 @@ module.exports = {
           use: [
             {
               loader: "css-loader",
-              options: { sourceMap: true }
+              options: { sourceMap: true, minimize: true }
             },
             {
               loader: "sass-loader",


### PR DESCRIPTION
This PR:

+ integrates `nunjucks` into the node app
+ fixes some styling in the webpack config
+ adds CSS minification
+ simplifies npm scripts so they now run on html/css/js together

+ adds a hashing mechanism for CSS/JS so that we can push updates which won't be overriden by locally cached files

^ on that last point, I realise this is not a totally elegant solution. What happens is, the HTML generator creates a hash (which is just current UNIX time), and needs to pass it to webpack, so that the hash in the HTML `<link>` and `<script>` tags is the same as the filenames of the CSS/JS bundles.

So to pass it, it simply outputs the hash into `stdout`, and webpack accepts that as a `--define` argument. I know `--define` isn't supposed to be used like this, but I'm not using it for anything else so why not. Webpack throws on unknown CLI args. I've added a comment explaining this to the webpack config.