### PR TITLE
Adaptive Social Feed pages

### DIFF
--- a/components/common-js/breakpoints.js
+++ b/components/common-js/breakpoints.js
@@ -1,0 +1,10 @@
+// TODO: this should later be defined in a JSON file which also sets it in SCSS
+const BREAKPOINTS = { s: 768, m: 1024, l: 1600 };
+
+const getBreakpoint = breakpoints => () => {
+  if (window.innerWidth >= breakpoints.l) return 'l';
+  if (window.innerWidth >= breakpoints.m) return 'm';
+  return 's';
+};
+
+export default getBreakpoint(BREAKPOINTS);

--- a/components/sections/flip-cards/_flip-cards.scss
+++ b/components/sections/flip-cards/_flip-cards.scss
@@ -21,6 +21,7 @@ $flip-cards-widths: (
   }
 
   @include respond-to(breakpoint(m)) {
+    @include rem(margin-bottom, spacing(xxl));
     max-width: map-get($flip-cards-section-widths, m);
   }
 

--- a/components/sections/social-feed/_social-feed.scss
+++ b/components/sections/social-feed/_social-feed.scss
@@ -45,7 +45,7 @@
   @include respond-to(breakpoint(s)) {
     @include flex(space-between, stretch, row, wrap);
     margin: 0 auto;
-    max-width: none;
+    max-width: 984px;
     text-align: left;
   }
 
@@ -56,7 +56,7 @@
 
     &:after,
     &:before {
-      @include rem(width, spacing(s));
+      @include rem(width, spacing(xl));
       background: $tscWhite;
       content: '';
       display: block;
@@ -76,11 +76,6 @@
   @include respond-to(breakpoint(l)) {
     @include rem(margin-bottom, spacing(xl) * 4);
     max-width: 1315px;
-
-    &:after,
-    &:before {
-      @include rem(width, spacing(xl));
-    }
   }
 }
 
@@ -135,8 +130,9 @@
   }
 
   @include respond-to(breakpoint(m)) {
-    @include rem(width, spacing(m));
-    @include rem(height, spacing(m));
+    @include rem(margin-right, spacing(s));
+    @include rem(width, spacing(xl));
+    @include rem(height, spacing(xl));
     @include transform-origin(center center);
     @include transform(rotate(180deg));
     @include transition(opacity 250ms);
@@ -158,6 +154,7 @@
     }
 
     &:last-of-type {
+      @include rem(margin, 0 0 0 spacing(s));
       @include transform(none);
       font-size: 0;
       padding: 0;
@@ -165,16 +162,6 @@
 
     &:hover {
       opacity: 1;
-    }
-  }
-
-  @include respond-to(breakpoint(l)) {
-    @include rem(margin-right, spacing(s));
-    @include rem(width, spacing(xl));
-    @include rem(height, spacing(xl));
-
-    &:last-of-type {
-      @include rem(margin, 0 0 0 spacing(s));
     }
   }
 }
@@ -197,15 +184,15 @@
     @include rem(padding, spacing(xxxs) * 0.5);
     display: inline-block;
     vertical-align: top;
-    width: 50%;
+    width: percentage(1/2);
   }
 
   @include respond-to(breakpoint(m)) {
-    @include rem(padding, 0 1px);
+    @include rem(padding, 0 spacing(xxxs) * 0.5);
     @include transitionTransform(transform 1s);
     @include transform(translateX(-100vw));
     position: absolute;
-    width: 25%;
+    width: percentage(1/3);
 
     &.social-feed__post--current {
       @include transform(translateX(0));
@@ -217,6 +204,10 @@
       position: absolute;
       display: block;
     }
+  }
+
+  @include respond-to(breakpoint(l)) {
+    width: percentage(1/4);
   }
   // override the default IG style attribute
   iframe {

--- a/components/sections/social-feed/_social-feed.scss
+++ b/components/sections/social-feed/_social-feed.scss
@@ -74,7 +74,7 @@
   }
 
   @include respond-to(breakpoint(l)) {
-    @include rem(margin-bottom, spacing(xl) * 4);
+    @include rem(margin-bottom, spacing(xl) * 3);
     max-width: 1315px;
   }
 }
@@ -173,6 +173,7 @@
 
 .social-feed__post {
   @include rem(padding, spacing(xxxs) * 0.5 0);
+  background-color: $tscWhite;
   box-sizing: border-box;
   width: 100%;
 

--- a/components/sections/social-feed/_social-feed.scss
+++ b/components/sections/social-feed/_social-feed.scss
@@ -50,7 +50,7 @@
   }
 
   @include respond-to(breakpoint(m)) {
-    @include rem(margin-bottom, spacing(xl) * 2 + spacing(s));
+    @include rem(margin-bottom, spacing(xl));
     -webkit-flex-wrap: nowrap;
     flex-wrap: nowrap;
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "webpack": "^3.5.4"
   },
   "devDependencies": {
+    "debounce": "^1.0.2",
     "nodemon": "^1.11.0"
   }
 }


### PR DESCRIPTION
Since Instagram embeds aren't as responsive as one would think, we need to change the feed page size adaptively – 4 on mobile/tablet, 3 on small desktop, and 4 on large desktop.

Because the pages are managed by JS, we can't simply do this with just media queries.

In this PR, we create an adaptive `postsPerPage` function which returns different values based on the current breakpoint. We also create an observer function which updates the number of currently visible posts based on `postsPerPage`. They both need to have separate `resize` listeners, because `postsPerPage` is used in other functions, too.

![screen shot 2017-09-22 at 16 56 12](https://user-images.githubusercontent.com/5719805/30753362-02b02182-9fb7-11e7-93db-d3f181452830.png)
![screen shot 2017-09-22 at 16 56 20](https://user-images.githubusercontent.com/5719805/30753363-02bc312a-9fb7-11e7-9f49-6d9d54ea4712.png)
