### PR TITLE
Cookie message

### DIFF
--- a/components/buttons/_button.scss
+++ b/components/buttons/_button.scss
@@ -150,3 +150,10 @@
 .button--loading {
   @include animation(loading 1.5s cubic-bezier(0, 0, 0, 1.1) infinite);
 }
+
+.button__x {
+  font-size: 3em;
+  display: inline-block;
+  line-height: fs(xxxs);
+  vertical-align: text-top;
+}

--- a/components/cookie-message/_cookie-message.scss
+++ b/components/cookie-message/_cookie-message.scss
@@ -1,0 +1,22 @@
+.cookie-message {
+  @include rem(padding, spacing(xxxs) spacing(xs));
+  background-color: $tscWhite;
+  box-shadow: 0 0 10px 1px rgba(0,0,0,0.3);
+  box-sizing: border-box;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 2;
+
+  @supports (position: sticky) or (position: -webkit-sticky) {
+    bottom: 0;
+    position: -webkit-sticky;
+    position: sticky;
+    top: auto;
+  }
+}
+
+.cookie-message__close {
+  @include rem(padding, spacing(xxxs) spacing(xs) 0);
+  float: right;
+}

--- a/components/cookie-message/cookie-message.js
+++ b/components/cookie-message/cookie-message.js
@@ -1,0 +1,17 @@
+const closeMessage = message => () => {
+  document.cookie = 'tsc_cookie_seen=true';
+  message.parentElement.removeChild(message);
+};
+
+const cookieMessage = message => {
+  const closeButton = message.querySelector('.cookie-message__close');
+  if (!closeButton) return message;
+
+  const close = closeMessage(message);
+  if (/tsc_cookie_seen/.test(document.cookie)) close();
+
+  closeButton.addEventListener('click', e => e.preventDefault() ^ close());
+  return message;
+};
+
+export { cookieMessage };

--- a/components/cookie-message/cookie-message.njk
+++ b/components/cookie-message/cookie-message.njk
@@ -1,0 +1,4 @@
+<div id="cookie-message" class="cookie-message" role="note">
+Together Science Can uses cookies. <a href="https://wellcome.ac.uk/about-us/terms-use#cookies" rel="noreferrer noopener" target="_blank">Read our policy</a>
+<a class="cookie-message__close button" href="#header">Accept and close</a>
+</div>

--- a/components/cookie-message/cookie-message.njk
+++ b/components/cookie-message/cookie-message.njk
@@ -1,4 +1,6 @@
 <div id="cookie-message" class="cookie-message" role="note">
-Together Science Can uses cookies. <a href="https://wellcome.ac.uk/about-us/terms-use#cookies" rel="noreferrer noopener" target="_blank">Read our policy</a>
-<a class="cookie-message__close button" href="#header">Accept and close</a>
+This site uses cookies. <a href="https://wellcome.ac.uk/about-us/terms-use#cookies" rel="noreferrer noopener" target="_blank">Read our policy</a>
+<a class="cookie-message__close button" href="#header" title="Accept and close">
+  <span class="button__x" role="presentation">&times;</span>
+</a>
 </div>

--- a/components/header/header--desktop.njk
+++ b/components/header/header--desktop.njk
@@ -1,6 +1,6 @@
 {% import "buttons/button.njk" as button %}
 
-<header class="header">
+<header class="header" id="header">
   <div class="logo-wrapper">
     <img class="logo" src="static/images/logo/tsc-logo.png" alt="Together Science Can logo">
   </div>

--- a/components/index.js
+++ b/components/index.js
@@ -10,6 +10,7 @@ import flipCard from './patterns/card/card.js';
 import { loadIntroVideoAfterImage } from './intro-video/introVideo.js';
 import { loadTextures } from './backgrounds/texturedBackgrounds.js';
 import { loadSocialPosts } from './sections/social-feed/socialFeed.js';
+import { cookieMessage } from './cookie-message/cookie-message.js';
 
 import setupAnalytics from './common-js/analytics.js';
 
@@ -17,6 +18,10 @@ const initialize = function() {
   if (!('requestAnimationFrame' in window)) return;
 
   document.documentElement.className += ' enhanced';
+
+  const cookieMessageElement = document.getElementById('cookie-message');
+  if (cookieMessageElement) cookieMessage(cookieMessageElement);
+
   // select all signup forms
   const forms = nodeList(document.getElementsByClassName('form__content'));
   forms.forEach(form => setupForm(form));

--- a/components/index.njk
+++ b/components/index.njk
@@ -34,5 +34,6 @@
     {% include "sections/secondary-signup/secondary-signup.njk" %}
   </main>
   {% include "footer/footer.njk" %}
+  {% include "cookie-message/cookie-message.njk" %}
 </body>
 </html>

--- a/components/index.scss
+++ b/components/index.scss
@@ -27,6 +27,7 @@
 @import 'patterns/share-panel/share-panel';
 @import 'patterns/card/card';
 
+@import 'cookie-message/cookie-message';
 @import 'header/header';
 @import 'intro-video/intro-video';
 @import 'footer/footer';


### PR DESCRIPTION
This PR adds the cookie message, which appears every page load until dismissed. It's using `position: sticky`, because `fixed` doesn't work well with the parallax effect. As a fallback, we just do `position: fixed; top: 0` and so leave the message stuck to top of `<html>`.

**Note:** the close button actually just says `x`, the screenshots are outdated.

![screen shot 2017-09-28 at 15 52 19](https://user-images.githubusercontent.com/5719805/30974267-2f5dac7c-a467-11e7-8f76-c30aa185ea4e.png)
![screen shot 2017-09-28 at 15 52 31](https://user-images.githubusercontent.com/5719805/30974268-2f60df5a-a467-11e7-8ccc-2ec1f81caf1e.png)
