### PR TITLE
Partner link update + cookie max-age

### DIFF
--- a/components/cookie-message/cookie-message.js
+++ b/components/cookie-message/cookie-message.js
@@ -1,5 +1,8 @@
+// 28 days
+const COOKIE_AGE = 86400 * 28;
+
 const closeMessage = message => () => {
-  document.cookie = 'tsc_cookie_seen=true';
+  document.cookie = `tsc_cookie_seen=true; max-age=${COOKIE_AGE}; path=/`;
   message.parentElement.removeChild(message);
 };
 

--- a/content/tsc.json
+++ b/content/tsc.json
@@ -196,7 +196,7 @@
       {
         "title": "Knut and Alice Wallenberg Foundation",
         "image_url": "static/images/partner-logos/wallenberg.svg",
-        "link": "http://kaw.wallenberg.org/"
+        "link": "https://kaw.wallenberg.org/en"
       },
       {
         "title": "The Max Planck Society",


### PR DESCRIPTION
This PR:

+ changes the Wallenberg Foundation link to English version of the site
+ made the cookie message cookie expire after 28 days rather than the session end