### PR TITLE
added a form footer for mobile and card forms

### DIFF
--- a/components/patterns/card/card.njk
+++ b/components/patterns/card/card.njk
@@ -22,6 +22,9 @@
         <div class="form__content">
           <h3 class="card__title">{{ flip_side.title | safe }}</h3>
           {% include "forms/card-signup-form.njk" %}
+          <p class="form__footer">
+            We'll send you well-timed news and ideas for how you can get involved. We won't share your email with anyone else.
+          </p>
         </div>
         <div class="form__success">
           <h3 class="form__title">{{ complete.title | safe }}</h3>

--- a/components/patterns/form/_form.scss
+++ b/components/patterns/form/_form.scss
@@ -35,13 +35,8 @@ $form-widths: (
 }
 
 .form__footer {
-  display: none;
-
-  @include respond-to(breakpoint(m)) {
-    display: block;
-    font-size: fs(xxxs);
-    line-height: lh(xxxs);
-  }
+  font-size: fs(xxxs);
+  line-height: lh(xxxs);
 
   @include respond-to(breakpoint(l)) {
     font-size: fs(xxs);


### PR DESCRIPTION
because they should legally be there.

![screen shot 2017-10-19 at 15 55 06](https://user-images.githubusercontent.com/5719805/31777415-e8ff66d2-b4e5-11e7-8400-47f4eb889cbc.png)
